### PR TITLE
fix: 日期时间带时区信息的兼容问题

### DIFF
--- a/wechatpayv3/core.py
+++ b/wechatpayv3/core.py
@@ -53,8 +53,8 @@ class Core():
             certificate = load_certificate(cert_str)
             if not certificate:
                 continue
-            now = datetime.utcnow()
-            if now < certificate.not_valid_before or now > certificate.not_valid_after:
+            now = datetime.now(timezone.utc)
+            if now < certificate.not_valid_before_utc or now > certificate.not_valid_after_utc:
                 continue
             self._certificates.append(certificate)
             if not self._cert_dir:


### PR DESCRIPTION
当 cryptography==42.0.3 版本较高时，会报：

CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_before_utc.

改用：datetime.now(timezone.utc)与certificate.not_valid_before_utc进行比较。